### PR TITLE
Polish the Linux .desktop file

### DIFF
--- a/data/azimuth.desktop
+++ b/data/azimuth.desktop
@@ -5,4 +5,4 @@ Icon=azimuth
 Name=Azimuth
 Terminal=false
 Type=Application
-Version=%AZ_VERSION_NUMBER
+Version=1.0

--- a/data/azimuth.desktop
+++ b/data/azimuth.desktop
@@ -6,3 +6,4 @@ Name=Azimuth
 Terminal=false
 Type=Application
 Version=1.0
+Categories=Game;ArcadeGame;


### PR DESCRIPTION
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-0.9.3.html says the version field is for the .desktop file standard and not program version. This is a common misconception. I also added a category which makes it easier to find on KDE.