### PR TITLE
Makefile: Allow installing using common DESTDIR var and fix permissions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,9 +524,9 @@ $(LINUX_DEB_DIR)/data/usr/share/icons/hicolor/%/apps/azimuth.png: \
 #=============================================================================#
 # Build rules to install linux version
 
-INSTALLDIR = /usr
-INSTALLBINDIR = $(INSTALLDIR)/bin
-INSTALLSHAREDIR = $(INSTALLDIR)/share
+PREFIX ?= /usr
+INSTALLBINDIR = $(DESTDIR)$(PREFIX)/bin
+INSTALLSHAREDIR = $(DESTDIR)$(PREFIX)/share
 INSTALLDOCDIR = $(INSTALLSHAREDIR)/doc/azimuth
 INSTALLICONDIR = $(INSTALLSHAREDIR)/icons/hicolor
 INSTALLTOOL = false
@@ -537,21 +537,21 @@ install: $(BINDIR)/azimuth $(BINDIR)/editor $(BINDIR)/muse $(BINDIR)/zfxr
 	mkdir -p $(INSTALLBINDIR)
 	install $(BINDIR)/azimuth $(INSTALLBINDIR)/azimuth
 ifeq "$(INSTALLTOOL)" "true"
-		install $(BINDIR)/editor $(INSTALLBINDIR)/azimuth-editor
-		install $(BINDIR)/muse $(INSTALLBINDIR)/azimuth-muse
-		install $(BINDIR)/zfxr $(INSTALLBINDIR)/azimuth-zfxr
+	install $(BINDIR)/editor $(INSTALLBINDIR)/azimuth-editor
+	install $(BINDIR)/muse $(INSTALLBINDIR)/azimuth-muse
+	install $(BINDIR)/zfxr $(INSTALLBINDIR)/azimuth-zfxr
 endif
 ifeq "$(INSTALLDOC)" "true"
-		mkdir -p $(INSTALLDOCDIR)
-		install doc/* README.md LICENSE $(INSTALLDOCDIR)
+	mkdir -p $(INSTALLDOCDIR)
+	install -m 0644 doc/* README.md LICENSE $(INSTALLDOCDIR)
 endif
 	mkdir -p $(INSTALLICONDIR)/128x128/apps/ $(INSTALLICONDIR)/64x64/apps/ $(INSTALLICONDIR)/48x48/apps/ $(INSTALLICONDIR)/32x32/apps/
-	install data/icons/icon_128x128.png $(INSTALLICONDIR)/128x128/apps/azimuth.png
-	install data/icons/icon_64x64.png $(INSTALLICONDIR)/64x64/apps/azimuth.png
-	install data/icons/icon_48x48.png $(INSTALLICONDIR)/48x48/apps/azimuth.png
-	install data/icons/icon_32x32.png $(INSTALLICONDIR)/32x32/apps/azimuth.png
+	install -m 0644 data/icons/icon_128x128.png $(INSTALLICONDIR)/128x128/apps/azimuth.png
+	install -m 0644 data/icons/icon_64x64.png $(INSTALLICONDIR)/64x64/apps/azimuth.png
+	install -m 0644 data/icons/icon_48x48.png $(INSTALLICONDIR)/48x48/apps/azimuth.png
+	install -m 0644 data/icons/icon_32x32.png $(INSTALLICONDIR)/32x32/apps/azimuth.png
 	mkdir -p $(INSTALLSHAREDIR)/applications
-	cp data/azimuth.desktop $(INSTALLSHAREDIR)/applications/azimuth.desktop
+	install -m 0644 data/azimuth.desktop $(INSTALLSHAREDIR)/applications/azimuth.desktop
 
 .PHONY : uninstall
 uninstall:


### PR DESCRIPTION
* Allow setting DESTDIR e.g. for packaging purpose
* Fix permissions when installing, data files should not have the execution bit set.